### PR TITLE
fix : 모달창 타입 오류 수정

### DIFF
--- a/src/components/confirm-modal.tsx
+++ b/src/components/confirm-modal.tsx
@@ -16,7 +16,7 @@ interface ConfirmModalProps {
     onClose: () => void
     onConfirm: () => void
     title: string
-    message: string
+    message: React.ReactNode // string -> React.ReactNode
     confirmText?: string
     cancelText?: string
     isLoading?: boolean


### PR DESCRIPTION
message라는 prop(또는 변수)에 JSX 요소 (<span>) 를 넣었는데,
타입은 string으로만 받도록 되어 있음.

message: (
  <span style={{ color: 'red' }}>정말로 이 공지사항을 삭제하시겠습니까?</span>
)
이 부분이 문자열(string)이 아니라 React Element (JSX) 라서 타입이 안 맞는 상황이였음

interface ConfirmModalProps {
  title: string;
  message: React.ReactNode; // ✅ JSX 포함 허용
}